### PR TITLE
Add MkDocs deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,20 @@
+name: Deploy MkDocs
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install mkdocs-material
+      - name: Build site
+        run: mkdocs build
+      - name: Deploy to GitHub Pages
+        run: mkdocs gh-deploy --force


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and deploy MkDocs docs on push to main

## Testing
- `pip install mkdocs mkdocs-material` *(fails: Could not find a version that satisfies the requirement mkdocs)*
- `mkdocs build` *(fails: command not found)*
- `mkdocs gh-deploy --force` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a7e6f7100832ea39f654fa519dd74